### PR TITLE
Refactor queryTimer `Timeout` in `useQuery` hook

### DIFF
--- a/src/hooks/query.tsx
+++ b/src/hooks/query.tsx
@@ -4,7 +4,7 @@ import { queryServer } from "../utils/query";
 import { Server } from "../utils/types";
 
 export const useQuery = () => {
-  const queryTimer = useRef<number | undefined>(undefined);
+  const queryTimer = useRef<NodeJS.Timeout | undefined>(undefined);
 
   const { selected, setSelected } = useServers();
   const selectedServer = useRef<Server | undefined>(selected);


### PR DESCRIPTION
Prevents `query.tsx` from failing the build.