### PR TITLE
Add package manager agnostic build and dev scripts for Tauri

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,9 @@
+import {
+  executeWithPackageManager,
+  getPackageManagerExecutable,
+} from "./common.js";
+
+(async () => {
+  const packageManager = await getPackageManagerExecutable();
+  await executeWithPackageManager(packageManager, "build");
+})();

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,0 +1,77 @@
+import { exec as _exec, spawn, spawnSync } from "child_process";
+import { promisify } from "node:util";
+const exec = promisify(_exec);
+
+/**
+ * @type {Record<'npm' | 'yarn', { args?: string[] }>}}
+ * @constant
+ */
+const PACKAGE_MANAGERS_OPTIONS = {
+  npm: {
+    args: ["run"],
+  },
+  yarn: {},
+};
+
+/**
+ *
+ * @param {keyof typeof PACKAGE_MANAGERS_OPTIONS} executable
+ * @returns {Promise<boolean>}
+ */
+const hasPackageManager = async (executable) => {
+  try {
+    await exec(`${executable} --version`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ *
+ * @returns {Promise<keyof typeof PACKAGE_MANAGERS_OPTIONS>}
+ */
+export const getPackageManagerExecutable = async () => {
+  const results = await Promise.allSettled(
+    Object.keys(PACKAGE_MANAGERS_OPTIONS).map((exec) =>
+      hasPackageManager(exec).then((isInstalled) => isInstalled && exec)
+    )
+  );
+
+  const packageManager = results.find(
+    ({ status, value }) => status === "fulfilled" && value
+  );
+
+  if (!packageManager) {
+    console.error(
+      `No package manager found. Supported: ${Object.keys(
+        PACKAGE_MANAGERS_OPTIONS
+      ).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  return packageManager.value;
+};
+
+/**
+ *
+ * @param {keyof typeof PACKAGE_MANAGERS_OPTIONS} packageManager
+ * @param {'build' | 'dev'} command
+ */
+export const executeWithPackageManager = async (packageManager, command) => {
+  const commandToRun = [
+    packageManager,
+    ...(PACKAGE_MANAGERS_OPTIONS[packageManager].args ?? []),
+    command,
+  ].join(" ");
+  const executable = spawn(commandToRun, {
+    shell: true,
+    cwd: process.cwd(),
+    timeout: 10000,
+  });
+
+  executable.stdout.on("data", (data) => console.log(data.toString()));
+  executable.stderr.on("data", (data) => console.error(data.toString()));
+  executable.on("exit", (code) => process.exit(code));
+};

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,9 @@
+import {
+  executeWithPackageManager,
+  getPackageManagerExecutable,
+} from "./common.js";
+
+(async () => {
+  const packageManager = await getPackageManagerExecutable();
+  await executeWithPackageManager(packageManager, "dev");
+})();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
-    "beforeDevCommand": "yarn dev",
-    "beforeBuildCommand": "yarn build",
+    "beforeDevCommand": "node ./scripts/dev.js",
+    "beforeBuildCommand": "node ./scripts/build.js",
     "devPath": "http://localhost:1420",
     "distDir": "../dist",
     "withGlobalTauri": false


### PR DESCRIPTION
This is an attempt at having package manager agnostic build and development scripts for Tauri.

Previously, if you didn't have `yarn` installed, both `build` and `dev` script could not be executed as the Tauri scripts were not taking into account the user's development environment.

This PR adds supports for both `npm` and `yarn`, but may easily be extended to support other package managers.

Closes #23 
