### PR TITLE
Build time flags to optimize binary size further

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,3 +44,10 @@ winreg = "0.52.0"
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+opt-level = "z"
+strip = true


### PR DESCRIPTION
Added some recommended build time flags to reduce tauri apps' binary size