### PR TITLE
Fix ru.ts

### DIFF
--- a/src/locales/translations/ru.ts
+++ b/src/locales/translations/ru.ts
@@ -91,7 +91,7 @@ export default {
   settings_lang_tab_title: "Языки",
   settings_advanced_tab_title: "Дополнительно",
   settings_advanced_discord_status: "Включить статус Discord",
-  join_discord: "Присоединиться к серверу Discord",
+  join_discord: "Присоединиться к Discord",
   samp_version: "SA-MP версия",
   change_version: "Изменить версию",
 };


### PR DESCRIPTION
![image](https://github.com/openmultiplayer/launcher/assets/55022836/df455830-7a38-4720-8760-b62e27968e87)
When using the Russian language, the text pops up on the ping tab. 
This little patch fixes it.