### PR TITLE
Update Portuguese (Brazil) Translation File Format and Keys

### DIFF
--- a/src/locales/translations/pt.ts
+++ b/src/locales/translations/pt.ts
@@ -3,20 +3,18 @@ export default {
   internet: "Internet",
   partners: "Parceiros",
   recently_joined: "Entrou Recentemente",
-  nickname: "Usuário",
+  nickname: "Nome de Usuário",
   settings: "Configurações",
   minimize: "Minimizar",
   maximize: "Maximizar",
   close: "Fechar",
-  add_server_modal_description_1:
-    "Adicione servidores manualmente à lista de favoritos.",
+  add_server_modal_description_1: "Adicione servidores manualmente à lista de favoritos.",
   add_server_modal_description_2: "Exemplo: 127.0.0.1:7777",
   add: "Adicionar",
   server: "Servidores",
   address: "Endereço IP",
   players: "Jogadores",
-  server_join_prompt_enter_password:
-    "Este servidor está trancado, por favor digite a senha.",
+  server_join_prompt_enter_password: "Este servidor está trancado, por favor digite a senha.",
   server_join_prompt_enter_password_input_placeholder: "Digite a senha...",
   server_join_prompt_nickname_input_placeholder: "Digite o Nome de Usuário...",
   connect: "Conectar",
@@ -42,56 +40,40 @@ export default {
   clear_recently_joined_list: "Limpar lista de servidores recentes",
   refresh_servers: "Atualizar lista de servidores",
   play: "Jogar",
-  remove_selected_server_from_favorites:
-    "Remover servidor selecionado dos favoritos",
-  add_selected_server_to_favorites:
-    "Adicionar servidor selecionado aos favoritos",
-  add_server: "Adicionar Servidor",
+  remove_selected_server_from_favorites: "Remover servidor selecionado dos favoritos",
+  add_selected_server_to_favorites: "Adicionar servidor selecionado aos favoritos",
+  add_server: "Adicionar servidor",
   hide_player_and_rule_list: "Ocultar lista de jogadores e regras",
   show_player_and_rule_list: "Mostrar lista de jogadores e regras",
   copy_server_info: "Copiar informações do servidor",
-  settings_gta_path_input_label:
-    "Caminho do GTA: San Andreas (onde o SA-MP está instalado)",
+  settings_gta_path_input_label: "Caminho do GTA: San Andreas (onde o SA-MP está instalado)",
   browse: "Selecionar",
-  settings_import_nickname_gta_path_from_samp:
-    "Importar configurações do SA-MP",
+  settings_import_nickname_gta_path_from_samp: "Importar configurações do SA-MP",
   settings_import_samp_favorite_list: "Importar lista de favoritos do SA-MP",
-  settings_reset_application_data:
-    "Redefinir dados do aplicativo (limpar configurações e listas)",
-  settings_new_update_available:
-    "⚠ Nova atualização disponível. Clique aqui para baixar a atualização! ⚠",
+  settings_reset_application_data: "Redefinir dados do aplicativo (limpar configurações e listas)",
+  settings_new_update_available: "⚠ Nova atualização disponível. Clique aqui para baixar a atualização! ⚠",
   settings_credits_made_by: "Feito com ❤️ por",
   settings_credits_view_source_on_github: "Código fonte disponível no GitHub",
   update_modal_update_available_title: "Atualização disponível!",
-  update_modal_update_available_description:
-    'Nova versão do launcher disponível!\nVersão do seu launcher: {{ version }}\nVersão atual do launcher: {{ newVersion }}\nClique em "Baixar" para abrir a página de downloads',
+  update_modal_update_available_description: 'Nova versão do launcher disponível!\nVersão do seu launcher: {{ version }}\nVersão atual do launcher: {{ newVersion }}\nClique em "Baixar" para abrir a página de downloads',
   download: "Baixar",
   update_modal_remind_me_next_time: "Me lembre mais tarde",
   update_modal_skip_this_update: "Ignorar esta atualização",
-  gta_path_modal_cant_find_game_title:
-    "Não foi possível encontrar o GTA: San Andreas!",
-  gta_path_modal_cant_find_game_description:
-    'Não é possível encontrar o GTA: San Andreas neste diretório:\n  - "{{ path }}"\nNão é possível encontrar "gta_sa.exe" no caminho fornecido',
-  open_settings: "Abrir Configurações",
+  gta_path_modal_cant_find_game_title: "Não foi possível encontrar o GTA: San Andreas!",
+  gta_path_modal_cant_find_game_description: 'Não é possível encontrar o GTA: San Andreas neste diretório:\n  - "{{ path }}"\nNão é possível encontrar "gta_sa.exe" no caminho fornecido',
+  open_settings: "Abrir configurações",
   cancel: "Cancelar",
   gta_path_modal_cant_find_samp_title: "Não foi possível encontrar o SA-MP!",
-  gta_path_modal_cant_find_samp_description:
-    'Não é possível encontrar a instalação do SA-MP neste diretório:\n  - "{{ path }}"\nNão é possível encontrar "samp.dll" no caminho fornecido\n',
-  notification_add_to_favorites_title: "Adicionado aos Favoritos!",
-  notification_add_to_favorites_description:
-    "{{ server }} foi adicionado à sua lista de favoritos.",
+  gta_path_modal_cant_find_samp_description: 'Não é possível encontrar a instalação do SA-MP neste diretório:\n  - "{{ path }}"\nNão é possível encontrar "samp.dll" no caminho fornecido\n',
+  notification_add_to_favorites_title: "Adicionado aos favoritos!",
+  notification_add_to_favorites_description: "{{ server }} foi adicionado à sua lista de favoritos.",
   nickname_modal_name_not_set_title: "Sem Nome de Usuário!",
-  nickname_modal_name_not_set_description:
-    "Você deve escolher um Nome de Usuário antes de entrar em um servidor.",
-  gta_path_modal_path_not_set_title:
-    "O caminho do GTA: San Andreas não está definido!",
-  gta_path_modal_path_not_set_description:
-    "Você não definiu o caminho do GTA: San Andreas, vá em configurações e procure a pasta do jogo.",
-  admin_permissions_required_modal_title:
-    "Permissões de Administrador necessárias!",
-  admin_permissions_required_modal_description:
-    'Parece que o seu jogo GTA: San Andreas requer permissões de Administrador para ser executado. Isso pode ser devido a vários motivos, como ter o jogo instalado na unidade “C”. Abra novamente o launcher do open.mp como administrador usando o botão "Executar como administrador" ou manualmente por você mesmo.',
-  run_as_admin: "Executar como Administrador",
+  nickname_modal_name_not_set_description: "Você deve escolher um Nome de Usuário antes de entrar em um servidor.",
+  gta_path_modal_path_not_set_title: "O caminho do GTA: San Andreas não está definido!",
+  gta_path_modal_path_not_set_description: "Você não definiu o caminho do GTA: San Andreas, vá em configurações e procure a pasta do jogo.",
+  admin_permissions_required_modal_title: "Permissões de Administrador necessárias!",
+  admin_permissions_required_modal_description: 'Parece que o seu jogo GTA: San Andreas requer permissões de Administrador para ser executado. Isso pode ser devido a vários motivos, como ter o jogo instalado na unidade "C". Abra novamente o launcher do open.mp como administrador usando o botão "Executar como administrador" ou manualmente por você mesmo.',
+  run_as_admin: "Executar como administrador",
   settings_general_tab_title: "Geral",
   settings_lang_tab_title: "Idiomas",
   settings_advanced_tab_title: "Avançado",
@@ -101,6 +83,7 @@ export default {
   change_version: "Mudar versão",
   offline: "Offline",
   from_gtasa_folder: "Da pasta do GTASA",
-  gta_path_modal_cant_find_samp_description_2:
-    "Escolha outra versão ou instale o SA-MP manualmente.",
+  gta_path_modal_cant_find_samp_description_2: "Escolha outra versão ou instale o SA-MP manualmente.",
+  add_or_play_external_server: "Adicionar aos favoritos ou jogar",
+  reconnect: "Reconectar"
 };


### PR DESCRIPTION
This PR updates the Portuguese (Brazil) translation file format and adds missing key/value pairs. The changes include formatting improvements and additional translations needed for new features.

## Changes Made
- Added the new translation keys:
  - `add_or_play_external_server`
  - `reconnect`
- Improved code formatting.
- Updated capitalization in some labels.
