### PR TITLE
Download R5-2 instead of R5-1

### DIFF
--- a/src/utils/game.ts
+++ b/src/utils/game.ts
@@ -198,7 +198,7 @@ export const startGame = async (
           title: t("download"),
           onPress: () => {
             shell.open(
-              "https://uifserver.net/download/sa-mp-0.3.7-R5-1-MP-install.exe"
+              "https://uifserver.net/download/sa-mp-0.3.7-R5-2-MP-install.exe"
             );
           },
         },


### PR DESCRIPTION
At https://sa-mp.mp/downloads/ the latest version is listed as 0.3.7-R5-2-MP however the launcher tries to pull R5-1 when clicking the Download button.

It seems to make sense to fetch the latest version as standard.