### PR TITLE
Fix Discord Update status Binding

### DIFF
--- a/src/containers/Settings/Tab/Advanced.tsx
+++ b/src/containers/Settings/Tab/Advanced.tsx
@@ -37,7 +37,7 @@ const Advanced = () => {
             toggleDiscordStatus(!shouldUpdateDiscordStatus);
           }}
         >
-          <CheckBox value={true} style={{ marginRight: sc(7) }} />
+          <CheckBox value={shouldUpdateDiscordStatus} style={{ marginRight: sc(7) }} />
           <Text semibold color={theme.textPrimary} size={2}>
             {`${t("settings_advanced_discord_status")} ${t(
               "settings_advanced_discord_status_requires_restart"


### PR DESCRIPTION
Fix the binding of the Discord Update Status with the checkbox in the Settings/Advanced page.

Refs: #291 