### PR TITLE
fix decode_buffer parsing gb2312 under specific conditions

### DIFF
--- a/src-tauri/src/helpers.rs
+++ b/src-tauri/src/helpers.rs
@@ -54,7 +54,12 @@ pub fn decode_buffer(buf: Vec<u8>) -> (String, String) {
     {
         // Use windows-1252 for various combinations
         Encoding::for_label("windows-1252".as_bytes()).unwrap_or(UTF_8)
-    } else if chardetng_encoding == "gbk" || chardet_encoding == "gb2312" {
+    } else if chardetng_encoding == "gbk"
+        || chardet_encoding == "gb2312"
+        || (chardetng_encoding == "euc-kr"
+            && chardet_encoding == "tis-620"
+            && charset_normalizer_encoding == "iso-8859-2")
+    {
         // Use GB18030 when chardetng detects GBK or chardet detects GB2312
         Encoding::for_label("GB18030".as_bytes()).unwrap_or(UTF_8)
     } else {


### PR DESCRIPTION
This pr attempts to fix #328 under specific conditions, but no matter what, there is still no optimal solution for short text parsing, and short text is the most easily misjudged.

Test text: "梦幻城v4.2.0" in gb2312 format.