### PR TITLE
fix cursor jump for nickname input

### DIFF
--- a/src/containers/JoinServerPrompt/index.tsx
+++ b/src/containers/JoinServerPrompt/index.tsx
@@ -1,6 +1,6 @@
 import { fs } from "@tauri-apps/api";
 import { t } from "i18next";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, FocusEvent } from "react";
 import {
   Image,
   StyleSheet,
@@ -180,16 +180,16 @@ const JoinServerPrompt = () => {
   }, [gtasaPath, server]);
 
   const handleNicknameChange = useCallback(
-    (text: string) => {
-      if (server) {
+    ({ nativeEvent }: FocusEvent) => {
+      if (server && nativeEvent) {
         if (settings) {
-          setServerSettings(server, text, settings.sampVersion);
+          setServerSettings(server, perServerNickname, settings.sampVersion);
         } else {
-          setServerSettings(server, text, undefined);
+          setServerSettings(server, perServerNickname, undefined);
         }
       }
     },
-    [server, settings, setServerSettings]
+    [server, settings, perServerNickname, setServerSettings]
   );
 
   const handleConnect = useCallback(() => {
@@ -330,7 +330,8 @@ const JoinServerPrompt = () => {
               placeholderTextColor={theme.textPlaceholder}
               placeholder={nickName}
               value={perServerNickname}
-              onChangeText={handleNicknameChange}
+              onChangeText={setPerServerNickname}
+              onBlur={handleNicknameChange}
               // @ts-ignore
               style={[styles.textInput, dynamicStyles.nicknameInput]}
             />


### PR DESCRIPTION
issue:
- saving settings onChangeText forces re-render of react and therefore, when editing your nickname, the cursor jumps to the end of the text.

fix:
- set local state on onChangeText via setPerServerNickname and moving handleNicknameChange to onBlur callback. This ensures the nickname gets saved only on focus loss of the input field.