### PR TITLE
fix: avoid resetting join prompt nickname edits

### DIFF
--- a/src/containers/JoinServerPrompt/index.tsx
+++ b/src/containers/JoinServerPrompt/index.tsx
@@ -69,18 +69,13 @@ const JoinServerPrompt = () => {
 
   useEffect(() => {
     if (settings) {
-      if (settings.nickname !== undefined) {
-        setPerServerNickname(settings.nickname);
-      }
-
-      if (settings.sampVersion !== undefined) {
-        setPerServerVersion(settings.sampVersion);
-      }
+      setPerServerNickname(settings.nickname || "");
+      setPerServerVersion(settings.sampVersion);
     } else {
       setPerServerNickname("");
       setPerServerVersion(undefined);
     }
-  }, [settings]);
+  }, [visible, server?.ip, server?.port]);
 
   useEffect(() => {
     setPassword(server && server.password ? server.password : "");
@@ -181,6 +176,8 @@ const JoinServerPrompt = () => {
 
   const handleNicknameChange = useCallback(
     (text: string) => {
+      setPerServerNickname(text);
+
       if (server) {
         if (settings) {
           setServerSettings(server, text, settings.sampVersion);
@@ -228,14 +225,14 @@ const JoinServerPrompt = () => {
       const version = getSampVersionFromName(value);
       if (server) {
         if (settings) {
-          setServerSettings(server, settings.nickname, version);
+          setServerSettings(server, perServerNickname, version);
         } else {
-          setServerSettings(server, undefined, version);
+          setServerSettings(server, perServerNickname || undefined, version);
         }
         setPerServerVersion(version);
       }
     },
-    [server, settings, setServerSettings]
+    [server, settings, perServerNickname, setServerSettings]
   );
 
   if (!visible) {


### PR DESCRIPTION
Fixes #363 

src/containers/JoinServerPrompt/index.tsx now initializes per-server nickname/version when the prompt opens or when the selected server changes.

- Nickname input updates local state immediately so persisted settings updates don’t overwrite active edits
- Version changes no longer pull nickname from a stale settings object and instead preserve the current edit