### PR TITLE
Fix SA-MP ping query payload

### DIFF
--- a/src-tauri/src/query.rs
+++ b/src-tauri/src/query.rs
@@ -158,10 +158,11 @@ impl Query {
         packet.push(query_type as u8);
 
         if query_type == 'p' {
-            packet.push(0);
-            packet.push(0);
-            packet.push(0);
-            packet.push(0);
+            let payload = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| (duration.as_nanos() as u32).to_le_bytes())
+                .unwrap_or([b'S', b'A', b'M', b'P']);
+            packet.extend_from_slice(&payload);
         }
 
         let amt = self


### PR DESCRIPTION
Servers using dataforest's DDoS protection always appear offline in the open.mp launcher, even though they display perfectly fine in the SA-MP launcher. This PR adjusts the payload so that it is not rejected.

Some affected servers:
- 143.20.37.52:7777
- 31.59.58.187:7777
- 185.213.240.246:7777

Before:
<img width="625" height="437" alt="image" src="https://github.com/user-attachments/assets/d85b1ded-2495-4cbb-9878-2efe12994bcd" />

After:
<img width="625" height="437" alt="image" src="https://github.com/user-attachments/assets/f9fdef88-30a3-441b-a233-67d35ae455ce" />

Note: I don’t work with the stack that is used here, so the changes were made through Codex.

Description from clanker:

> This fixes SA-MP server ping queries to follow the documented SA-MP query protocol.
> 
> Previously, the launcher sent the `p` ping query with four zero bytes as the payload. According to the SA-MP query mechanism, the ping packet should include four pseudo-random bytes after the `p` query type. Some servers, including ones behind DataForest DDoS protection, appear to reject or ignore the all-zero ping payload even though they still respond to other query types such as info, rules, and players.
>
> The change replaces the hardcoded zero payload with a four-byte value generated from the current system time. The existing ping send/receive flow is otherwise unchanged, keeping the fix minimal while making the ping packet match the expected SA-MP format.
