### PR TITLE
Resolve CLI hostname to IPv4 to fix hyphenated host truncation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -78,8 +78,8 @@ pub fn get_samp_favorite_list() -> String {
     samp::get_samp_favorite_list()
 }
 
-#[tauri::command]
-pub fn resolve_hostname(hostname: String) -> std::result::Result<String, String> {
+// resolves a hostname to its first ipv4 address
+pub fn resolve_hostname_to_ipv4(hostname: &str) -> std::result::Result<String, String> {
     use std::net::{IpAddr, ToSocketAddrs};
 
     if hostname.is_empty() {
@@ -98,6 +98,11 @@ pub fn resolve_hostname(hostname: String) -> std::result::Result<String, String>
     }
 
     Err(format!("No IPv4 address found for hostname '{}'", hostname))
+}
+
+#[tauri::command]
+pub fn resolve_hostname(hostname: String) -> std::result::Result<String, String> {
+    resolve_hostname_to_ipv4(&hostname)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -78,31 +78,9 @@ pub fn get_samp_favorite_list() -> String {
     samp::get_samp_favorite_list()
 }
 
-// resolves a hostname to its first ipv4 address
-pub fn resolve_hostname_to_ipv4(hostname: &str) -> std::result::Result<String, String> {
-    use std::net::{IpAddr, ToSocketAddrs};
-
-    if hostname.is_empty() {
-        return Err("Hostname cannot be empty".to_string());
-    }
-
-    let addr = format!("{}:80", hostname);
-    let addrs = addr
-        .to_socket_addrs()
-        .map_err(|e| format!("Failed to resolve hostname '{}': {}", hostname, e))?;
-
-    for ip in addrs {
-        if let IpAddr::V4(ipv4) = ip.ip() {
-            return Ok(ipv4.to_string());
-        }
-    }
-
-    Err(format!("No IPv4 address found for hostname '{}'", hostname))
-}
-
 #[tauri::command]
 pub fn resolve_hostname(hostname: String) -> std::result::Result<String, String> {
-    resolve_hostname_to_ipv4(&hostname)
+    helpers::resolve_hostname_to_ipv4(&hostname)
 }
 
 #[tauri::command]

--- a/src-tauri/src/helpers.rs
+++ b/src-tauri/src/helpers.rs
@@ -81,6 +81,28 @@ pub fn decode_buffer(buf: Vec<u8>) -> (String, String) {
     (buff_output, actual_encoding.name().to_string())
 }
 
+// resolves a hostname to its first ipv4 address
+pub fn resolve_hostname_to_ipv4(hostname: &str) -> std::result::Result<String, String> {
+    use std::net::{IpAddr, ToSocketAddrs};
+
+    if hostname.is_empty() {
+        return Err("Hostname cannot be empty".to_string());
+    }
+
+    let addr = format!("{}:80", hostname);
+    let addrs = addr
+        .to_socket_addrs()
+        .map_err(|e| format!("Failed to resolve hostname '{}': {}", hostname, e))?;
+
+    for ip in addrs {
+        if let IpAddr::V4(ipv4) = ip.ip() {
+            return Ok(ipv4.to_string());
+        }
+    }
+
+    Err(format!("No IPv4 address found for hostname '{}'", hostname))
+}
+
 pub fn copy_files(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> crate::errors::Result<()> {
     let files = fs::read_dir(src).map_err(|e| crate::errors::LauncherError::from(e))?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -130,9 +130,17 @@ async fn handle_cli_args() -> Result<()> {
                     &omp_client_path
                 };
 
+                // resolve hostname to ipv4 so the game does not truncate hyphenated hosts
+                let host = args.host.as_ref().unwrap();
+                let resolved_host =
+                    commands::resolve_hostname_to_ipv4(host).unwrap_or_else(|e| {
+                        info!("Failed to resolve hostname '{}', using raw value: {}", host, e);
+                        host.clone()
+                    });
+
                 run_samp(
                     args.name.as_ref().unwrap(),
-                    args.host.as_ref().unwrap(),
+                    &resolved_host,
                     args.port.unwrap(),
                     gamepath,
                     &format!("{}/{}", gamepath, SAMP_DLL),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -133,7 +133,7 @@ async fn handle_cli_args() -> Result<()> {
                 // resolve hostname to ipv4 so the game does not truncate hyphenated hosts
                 let host = args.host.as_ref().unwrap();
                 let resolved_host =
-                    commands::resolve_hostname_to_ipv4(host).unwrap_or_else(|e| {
+                    helpers::resolve_hostname_to_ipv4(host).unwrap_or_else(|e| {
                         info!("Failed to resolve hostname '{}', using raw value: {}", host, e);
                         host.clone()
                     });


### PR DESCRIPTION
Fixes #415

When launching via the command line with a hyphenated hostname (e.g. -h s2.gta-mp.cz -p 7777), the game connects to s2.gta:7777 instead of s2.gta-mp.cz:7777.

The launcher's own CLI parsing is fine, gumdrop returns the full s2.gta-mp.cz. The truncation happens inside the game: SA-MP parses gta_sa.exe's command line itself and treats the -mp segment as a separate flag.

The UI launch flow resolves the hostname to a numeric IPv4 (getIpAddress then resolve_hostname) before calling inject, so the game never receives a hyphenated hostname. The CLI launch path in handle_cli_args skipped this step and passed the raw host straight to run_samp.

This change resolves the host to an IPv4 in the CLI path before reaching run_samp, mirroring the UI behaviour. resolve_hostname is refactored into a reusable resolve_hostname_to_ipv4 helper. If resolution fails (e.g. offline) it falls back to the raw value, so behaviour is never worse than before.

Verified in isolation that gumdrop keeps the full s2.gta-mp.cz and that the resolver turns it into a numeric IPv4 with no hyphen for the game to misparse.