### PR TITLE
fix: refetch server list when the network comes back online

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,6 +200,19 @@ const App = memo(() => {
     };
   }, [windowResizeListener, initializeApp]);
 
+  useEffect(() => {
+    // Re-fetch the server list when the network comes back online,
+    // in case the initial fetch failed because the launcher started offline.
+    const handleOnline = () => {
+      fetchServers();
+    };
+
+    window.addEventListener("online", handleOnline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+    };
+  }, []);
+
   const handleLoadingEnd = useCallback(async () => {
     const endTimer = PerformanceMonitor.time("loading-end");
     setLoading(false);


### PR DESCRIPTION
Fixes #385

The server list is fetched once at startup. If the launcher starts while the machine is offline, the request fails and the list stays empty forever, even after the connection comes back.

This listens for the \online\ window event and re-runs \etchServers()\ when connectivity returns, so the internet list and favorites load without restarting the launcher.