### PR TITLE
docs: add translations contributing note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ yarn start
 yarn tauri build
 ```
 
+# Translations
+
+Translations live in `src/locales/translations/`, one TypeScript file per language (e.g. `es.ts`, `ru.ts`). The English file `en.ts` is the source of truth and every language file must keep the same keys.
+
+To add or update a language:
+
+1. Copy `src/locales/translations/en.ts` to a new file (e.g. `xx.ts`) and translate the values, keeping the keys unchanged.
+2. Register the new language in `src/locales/index.ts`: add it to `loadTranslation`, `LanguageType` and `LANGUAGE_METADATA`.
+3. Open a pull request.
+
+Missing keys fall back to English, so keeping keys in sync with `en.ts` is the only requirement.
+
 # Donations
 
 While open.mp is a totally free project and everyone in the team dedicates their time on this project to provide the best for the community, we can still use whatever contribution by anyone, to cover our costs or motivate developers.  


### PR DESCRIPTION
References #380 and #407

Adds a short section to the README explaining how translations work and how to add or update a language, so translators know where the files live and what to touch (\loadTranslation\, \LanguageType\, \LANGUAGE_METADATA\ in \src/locales/index.ts\).