### PR TITLE
Reload the server list when the connection comes back

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,6 +200,16 @@ const App = memo(() => {
     };
   }, [windowResizeListener, initializeApp]);
 
+  useEffect(() => {
+    // Refetch the server list once we get a connection back
+    const handleOnline = () => {
+      fetchServers();
+    };
+
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, []);
+
   const handleLoadingEnd = useCallback(async () => {
     const endTimer = PerformanceMonitor.time("loading-end");
     setLoading(false);


### PR DESCRIPTION
Fixes #385

The list only gets fetched once at startup, so if you open the launcher while offline it stays empty even after you get a connection back. I added a listener for the \online\ event that refetches the list, no restart needed.