### PR TITLE
fix: make IPC listener lazy to avoid antivirus false positives

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,6 +22,8 @@ pub async fn inject(
         omp_file
     };
 
+    crate::ipc::ensure_listening();
+
     match injector::run_samp(
         name,
         ip,

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -2,7 +2,8 @@ use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::io::BufRead;
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use tauri::{AppHandle, Manager, WindowBuilder, WindowUrl};
 
@@ -11,6 +12,25 @@ use crate::constants::*;
 type SharedStreams = Arc<Mutex<HashMap<i32, TcpStream>>>;
 
 pub static GAME_STREAMS: Lazy<SharedStreams> = Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+
+static IPC_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+static IPC_STARTED: AtomicBool = AtomicBool::new(false);
+
+pub fn init_ipc(app_handle: AppHandle) {
+    let _ = IPC_HANDLE.set(app_handle);
+}
+
+pub fn ensure_listening() {
+    if IPC_STARTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    if let Some(handle) = IPC_HANDLE.get() {
+        listen_for_ipc(handle.clone());
+    }
+}
 
 fn create_overlay_window(
     app: &tauri::AppHandle,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -222,7 +222,7 @@ fn setup_tauri_app(app: &mut tauri::App) -> std::result::Result<(), Box<dyn std:
     #[cfg(windows)]
     setup_deeplinks(handle.clone())?;
 
-    ipc::listen_for_ipc(handle);
+    ipc::init_ipc(handle);
     Ok(())
 }
 


### PR DESCRIPTION
The IPC TCP listener was binding on startup which was triggering antivirus detections (ESET + Microsoft were flagging it on VirusTotal, 1-2/70). Made the listener lazy so it only opens when you actually join a server instead of on startup.

Ran both builds through VirusTotal:
- Before: 1-70 (ESET + Microsoft)
- After: 0/67

Just moved the bind to right before DLL injection in the inject command, stored the app handle with a OnceLock so it's available when needed.

Closes #419